### PR TITLE
Start interactive debugging with `make launch-debug`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,29 +18,32 @@ LIBPATHS	+= -L./external/lib
 LIBS    	+= -lconfig -lSDL12 -lTouchControlOverlay
 
 # change these as needed (debug right now)
-CFLAGS 	:= $(INCLUDE) -V4.6.3,gcc_ntoarmv7le -O2 -g
+CFLAGS 	:= $(INCLUDE) -V4.6.3,gcc_ntoarmv7le -O2 -g -DDEBUG
 LDFLAGS	:= $(LIBPATHS) $(LIBS)
 
 ASSET 	:= Device-Debug
 BINARY	:= Term48-dev
+BINARY_PATH := $(ASSET)/$(BINARY)
 
 SRCS  	:= $(wildcard src/*.c)
 OBJS  	:= $(SRCS:.c=.o )
 
 include ./signing/bbpass
 
+.PHONY: all clean package-debug deploy launch-debug
+
 all: package-debug
 
 $(BINARY): $(OBJS)
 	mkdir -p $(ASSET)
-	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS) -o $(ASSET)/$(BINARY)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS) -o $(BINARY_PATH)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
 	@rm -fv src/*.o
-	@rm -fv $(ASSET)/$(BINARY)
+	@rm -fv $(BINARY_PATH)
 	@rmdir -v $(ASSET)
 	@rm -fv $(BINARY).bar
 
@@ -53,3 +56,7 @@ BBIP ?= 169.254.0.1
 
 deploy: package-debug
 	blackberry-deploy -installApp $(BBIP) -password $(BBPASS) $(BINARY).bar
+
+launch-debug: deploy
+	blackberry-deploy -debugNative -device $(BBIP) -password $(BBPASS) -launchApp $(BINARY).bar
+	trap '' SIGINT; BINARY_PATH=$(BINARY_PATH) BBIP=$(BBIP) ntoarm-gdb -x scripts/gdb-debug-setup.py

--- a/scripts/gdb-debug-setup.py
+++ b/scripts/gdb-debug-setup.py
@@ -1,0 +1,50 @@
+import os
+import gdb
+
+cwd = os.getcwd()
+base_dir = os.environ['BASE_DIR_REPLACED'] # BBNDK directory
+qnx_target = os.environ['QNX_TARGET']
+
+bbip = os.environ.get('BBIP', None)
+if not bbip:
+    raise gdb.GdbError("Set target device IP in env. var. BBIP")
+binary_path = os.environ.get('BINARY_PATH', None)
+if not binary_path:
+    raise gdb.GdbError("Set path to the target binary in env. var. BINARY_PATH")
+binary_name = os.path.basename(binary_path)
+
+solib_search_paths = map(lambda p: qnx_target + p, [
+    "../target-override/armle-v7/lib",
+    "../target-override/armle-v7/usr/lib",
+    "../target-override/armle-v7/usr/lib/qt4/lib",
+    "../target-override/armle-v7/usr/lib/qt5/lib",
+    "/armle-v7/lib",
+    "/armle-v7/usr/lib",
+    "/armle-v7/usr/lib/qt4/lib",
+    "/armle-v7/usr/lib/qt5/lib",
+])
+
+map(gdb.execute, [
+    "cd %s" % cwd,
+    "set breakpoint pending on",
+    "enable pretty-printer",
+    "source %sconfiguration/org.eclipse.osgi/bundles/100/1/.cp/printers/gdbinit" % base_dir,
+    "set print object on",
+    "set print sevenbit-strings on",
+    "set auto-solib-add on",
+    "set solib-search-path %s" % ";".join(solib_search_paths),
+    "file %s" % binary_path,
+    "target qnx %s:8000" % bbip
+])
+
+pids = filter(lambda l: binary_name in l, gdb.execute("info pidlist", to_string=True).split('\n'))
+if not pids:
+    raise gdb.GdbError("Make sure the target application has been started!")
+
+[pid, thread_pid] = pids[0].split(' - ')
+pid = thread_pid.split('/')[0]
+
+map(gdb.execute, [
+    "attach %s" % pid,
+    "handle SIGTERM nostop noprint"
+])


### PR DESCRIPTION
You'll probably want this feature to tackle any debugging issues. 
`make launch-debug` will deploy the debug package, start it, launch, and attach a GDB session.
Haven't figured out how to get console output in GDB instead of the device log files. For now you can use the GDB command [`dprintf`](https://sourceware.org/gdb/onlinedocs/gdb/Dynamic-Printf.html) to print things out as needed.