### PR TITLE
Add blackberry-connect helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ signing/bbpass
 signing/*.csk
 signing/*.bar
 signing/*.p12
+signing/ssh-key*

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ signing/debugtoken.bar:
 package-debug: $(BINARY) signing/debugtoken.bar
 	blackberry-nativepackager -package $(BINARY).bar bar-descriptor.xml -devMode -debugToken signing/debugtoken.bar
 
+signing/ssh-key:
+	$(error SSH key error: signing/ssh-key not found. `cd signing` and `make ssh-key`))
+connect: signing/ssh-key
+	blackberry-connect $(BBIP) -password $(BBPASS) -sshPublicKey signing/ssh-key.pub
+
 BBIP ?= 169.254.0.1
 
 deploy: package-debug

--- a/README.md
+++ b/README.md
@@ -44,3 +44,19 @@ As this is a work in progress, pull requests or feature requests are welcome. Pl
 * Run `make` in `signing/Makefile` to request and deploy the token to your device.
 
 Important: any symbols need to be escaped according to bash / Makefile rules e.g. backslashes before symbols `\!` and double dollar signs `\$$`.
+
+# Debugging with GDB
+
+To connect to the target device and enable debug tools such as GDB, the `blackberry-connect` tool must be started with the right arguments. For this, two terminals must have the correct `bbndk-env` environment loaded (or run the `make connect` command in the background).
+
+## Terminal 1: `blackberry-connect`
+* Start in the Term48 root directory.
+* `cd signing`
+* If the SSH key hasn't been generated yet, run `make ssh-key`.
+* `make connect`
+* Leave terminal running until done debugging.
+
+## Terminal 2: `gdb`
+* Start in the Term48 root directory.
+* `make launch-debug`
+* The package will be built, deployed to target device, and launched stopped. On host, `ntoarm-gdb` will start, connect to target device, and attach to the application process. To continue execution, run the GDB command `continue`. Further information on GDB can be found online.

--- a/signing/Makefile
+++ b/signing/Makefile
@@ -3,6 +3,9 @@ include ./bbpass
 KEYSTORE   := ./author.p12
 BBIDTOKEN  := ./bbidtoken.csk
 DEBUGTOKEN := ./debugtoken.bar
+SSHKEY     := ./ssh-key
+
+.PHONY: all author-info deploy-token connect
 
 all: deploy-token
 
@@ -13,6 +16,10 @@ endif
 	@echo Generating keypairs and writing to keystore...
 	blackberry-keytool -genkeypair -keystore $(KEYSTORE) -storepass $(KEYSTOREPASS) -author $(CNNAME)
 	blackberry-debugtokenrequest -keystore $(KEYSTORE) -bbidtoken $(BBIDTOKEN) -storepass $(KEYSTOREPASS) -deviceID 0x$(BBPIN) $(DEBUGTOKEN)
+
+$(SSHKEY):
+	@echo Generating SSH key...
+	ssh-keygen -b 4096 -t rsa -f $(SSHKEY) -q -N ""
 
 author-info: $(DEBUGTOKEN)
 	@echo


### PR DESCRIPTION
Realized that `blackberry-connect` needs to be started before using debug tools such as GDB.